### PR TITLE
JEI subtypes for science packs

### DIFF
--- a/src/main/java/com/portingdeadmods/researchd/compat/jei/ResearchdJeiPlugin.java
+++ b/src/main/java/com/portingdeadmods/researchd/compat/jei/ResearchdJeiPlugin.java
@@ -2,8 +2,10 @@ package com.portingdeadmods.researchd.compat.jei;
 
 import com.portingdeadmods.researchd.Researchd;
 import com.portingdeadmods.researchd.compat.JEICompat;
+import com.portingdeadmods.researchd.registries.ResearchdItems;
 import mezz.jei.api.IModPlugin;
 import mezz.jei.api.JeiPlugin;
+import mezz.jei.api.registration.ISubtypeRegistration;
 import mezz.jei.api.runtime.IJeiRuntime;
 import net.minecraft.resources.ResourceLocation;
 import org.jetbrains.annotations.NotNull;
@@ -13,7 +15,7 @@ public final class ResearchdJeiPlugin implements IModPlugin {
     public static final ResourceLocation UID = Researchd.rl("researchd_jei_plugin");
 
     @Override
-    public void onRuntimeAvailable(IJeiRuntime jeiRuntime) {
+    public void onRuntimeAvailable(@NotNull IJeiRuntime jeiRuntime) {
         JEICompat.RUNTIME = jeiRuntime;
     }
 
@@ -25,5 +27,10 @@ public final class ResearchdJeiPlugin implements IModPlugin {
     @Override
     public @NotNull ResourceLocation getPluginUid() {
         return UID;
+    }
+
+    @Override
+    public void registerItemSubtypes(@NotNull ISubtypeRegistration registration) {
+        registration.registerSubtypeInterpreter(ResearchdItems.RESEARCH_PACK.get(), new SciencePackSubtypeInterpreter());
     }
 }

--- a/src/main/java/com/portingdeadmods/researchd/compat/jei/SciencePackSubtypeInterpreter.java
+++ b/src/main/java/com/portingdeadmods/researchd/compat/jei/SciencePackSubtypeInterpreter.java
@@ -1,0 +1,25 @@
+package com.portingdeadmods.researchd.compat.jei;
+
+import com.portingdeadmods.researchd.registries.ResearchdDataComponents;
+import mezz.jei.api.ingredients.subtypes.ISubtypeInterpreter;
+import mezz.jei.api.ingredients.subtypes.UidContext;
+import net.minecraft.world.item.ItemStack;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+
+public class SciencePackSubtypeInterpreter implements ISubtypeInterpreter<ItemStack> {
+
+    @Override
+    public @Nullable Object getSubtypeData(@NotNull ItemStack stack, @NotNull UidContext context) {
+        var component = stack.get(ResearchdDataComponents.RESEARCH_PACK.get());
+        if (component == null || component.researchPackKey().isEmpty()) {
+            return null;
+        }
+        return component.researchPackKey().get().location().toString();
+    }
+
+    @Override
+    public @NotNull String getLegacyStringSubtypeInfo(@NotNull ItemStack stack, @NotNull UidContext context) {
+        return "";
+    }
+}


### PR DESCRIPTION
Each science pack is treated as an individual science pack.
Looking up the recipe for another pack in JEI, no longer shows recipes of other science packs.
All science packs now show up in JEI.

Looking up crafting before
<img width="500" height="300" alt="crafting before" src="https://github.com/user-attachments/assets/085cbf5c-532e-4cf9-b2d3-9cc63b30813a" />

Looking up crafting after
<img width="500" height="300" alt="recipe" src="https://github.com/user-attachments/assets/263dfc11-6463-461c-9a69-821f65ca58b3" />

JEI registered items before
<img width="500" height="300" alt="subtypes before" src="https://github.com/user-attachments/assets/0fbdf77d-b362-4dcb-805e-f08fb35ce34c" />

JEI registered items after
<img width="500" height="300" alt="subtypes" src="https://github.com/user-attachments/assets/6b89df2d-caf4-40c6-8073-1c32c6162c40" />
