### PR TITLE
fix(native team): join/leave/transfer robustness

### DIFF
--- a/src/main/java/com/portingdeadmods/researchd/utils/researches/ResearchTeamHelperServer.java
+++ b/src/main/java/com/portingdeadmods/researchd/utils/researches/ResearchTeamHelperServer.java
@@ -143,7 +143,7 @@ public final class ResearchTeamHelperServer {
         if (team != null
                 && ((team.getSocialManager().containsSentInvite(requesterId))
                         || ResearchdCompatHandler.isFTBTeamsEnabled())) {
-            ResearchTeamHelperServer.handleLeaveTeam(requester);
+            detachFromPreviousTeams(requester, team, teamManager);
 
             teamManager.addTeam(team);
             if (!ResearchdCompatHandler.isFTBTeamsEnabled())
@@ -168,6 +168,27 @@ public final class ResearchTeamHelperServer {
             refreshPlayerManagement(team, level);
             // PacketDistributor.sendToPlayer(requester, new RefreshResearchesPayload());
         }
+    }
+
+    /** Detach the requester from whatever research team they were in before joining {@code target}.
+     *  Unlike {@code handleLeaveTeam}, this never auto-creates a fresh solo team: joining another
+     *  team's member list must not leave the player registered in two teams at once. */
+    private static void detachFromPreviousTeams(
+            @NotNull ServerPlayer requester, ResearchTeam target, ResearchTeamManager teamManager) {
+        UUID requesterId = requester.getUUID();
+        ResearchTeam oldTeam = getTeamByMember(requester);
+        if (oldTeam == null || oldTeam.getId().equals(target.getId())) return;
+
+        if (oldTeam.isOwner(requesterId) && oldTeam.getMembers().size() <= 1) {
+            // Own solo team -> drop it entirely; the player is now joining someone else's team.
+            teamManager.removeTeam(oldTeam.getId());
+            PacketDistributor.sendToAllPlayers(new RemoveTeamPayload(oldTeam.getId()));
+        } else if (!oldTeam.isOwner(requesterId) && oldTeam instanceof ResearchTeamImpl oldImpl) {
+            oldImpl.removeMember(requesterId);
+            PacketDistributor.sendToAllPlayers(new SyncTeamPayload(oldImpl));
+        }
+        // Owner of a multi-member team can't be detached silently here; the normal leave/transfer
+        // flow handles that case explicitly.
     }
 
     public static void handleIgnoreTeam(@NotNull ServerPlayer requester, UUID memberOfTeam) {
@@ -224,10 +245,31 @@ public final class ResearchTeamHelperServer {
 
                 // Team Leader Specified
                 handleTransferOwnership(requester, nextToLead);
+
+                // Handing over leadership is not the same as leaving: actually remove ourselves
+                // from the team now, otherwise the former leader is only demoted to moderator
+                // and can never leave the team through this path.
+                team.removeMember(requesterId);
+                if (team instanceof ResearchTeamImpl teamImpl) {
+                    PacketDistributor.sendToAllPlayers(new SyncTeamPayload(teamImpl));
+                }
+
+                if (!ResearchdCompatHandler.isFTBTeamsEnabled())
+                    requester.sendSystemMessage(ResearchdTranslations.component(ResearchdTranslations.Team.LEFT_TEAM));
+
+                createTeamForPlayerSynced(level, requesterId, teamManager);
+                PacketDistributor.sendToPlayer(requester, ClearGraphCachePayload.INSTANCE);
+
+                refreshPlayerManagement(team, level);
             }
         } else {
             // Is not Owner -> Just remove member out of the team and create a default one.
             removeMember(requester);
+            // Broadcast the removal so teammates' clients drop the leaving player, otherwise
+            // they keep showing the member until a restart (incomplete leave).
+            if (team instanceof ResearchTeamImpl teamImpl) {
+                PacketDistributor.sendToAllPlayers(new SyncTeamPayload(teamImpl));
+            }
             if (!ResearchdCompatHandler.isFTBTeamsEnabled())
                 requester.sendSystemMessage(ResearchdTranslations.component(ResearchdTranslations.Team.LEFT_TEAM));
             createTeamForPlayerSynced(level, requesterId, teamManager);
@@ -410,15 +452,16 @@ public final class ResearchTeamHelperServer {
 
     public static @NotNull Component formatMembers(@NotNull ResearchTeam team, @NotNull Level level) {
         MutableComponent formattedTeam = Component.literal(team.getName()).withStyle(ChatFormatting.AQUA);
-        formattedTeam.append(Component.literal(" has %d member%s: "
-                        .formatted(team.getMembers().size(), team.getMembers().size() == 1 ? "" : "s"))
+        long memberCount = team.getMembers().size();
+        formattedTeam.append(Component.literal(" has %d member%s: ".formatted(memberCount, memberCount == 1 ? "" : "s"))
                 .withStyle(ChatFormatting.WHITE));
 
         for (TeamMember member : team.getMembers()) {
-            Player player = level.getPlayerByUUID(member.player());
-            if (player != null)
-                formattedTeam.append(
-                        Component.literal(player.getName().getString() + " ").withStyle(ChatFormatting.AQUA));
+            // Use the name cache so offline members are still listed instead of silently dropped.
+            String name = AllPlayersCache.getName(member.player());
+            formattedTeam.append(
+                    Component.literal((name != null ? name : member.player().toString()) + " ")
+                            .withStyle(ChatFormatting.AQUA));
         }
 
         return formattedTeam;


### PR DESCRIPTION
## What
Fixes several bugs in Researchd's **native** team logic (used when FTB Teams integration is not acting):

- Joining another team no longer silently keeps the player in a duplicate solo team (added `detachFromPreviousTeams`, which never auto-creates a fresh solo team while joining another team).
- Handing over team leadership now actually **removes the former leader** from the team, instead of only demoting them to moderator (previously they could never leave through this path).
- Broadcasts `SyncTeamPayload` after a member leaves / leadership transfer so all clients immediately drop the removed member (previously an incomplete leave persisted until restart).
- Member list now shows offline members correctly via `AllPlayersCache`.

Changed file: `ResearchTeamHelperServer.java` (+50 / -7)

## Known issue: FTB Teams integration
Separate from the native fixes above, **FTB Teams integration currently does not work reliably**:
- Creating / inviting / joining an FTB team works fine (FTB itself logs these events correctly).
- But Researchd does **not** create a matching research team, and research progress is **not** synced between FTB teammates.
- Root cause is still under investigation: `changeTeamHandler` may be a no-op when the FTB team owner has no Researchd team yet (`target == null`), so a newly-joining member is silently dropped.

The native team logic in this PR is solid, but FTB-linked play should be tested separately — it is known to need more work.